### PR TITLE
Added options for t,W,Z,Q MC

### DIFF
--- a/preprocess/plugins/BuildFile.xml
+++ b/preprocess/plugins/BuildFile.xml
@@ -10,4 +10,5 @@
 <use name="clhep"/>
 <use name="ROOT"/>
 
+<flags CXXFLAGS="-O0 -g3 -fno-inline"/>
 <flags EDM_PLUGIN="1"/>

--- a/preprocess/plugins/edanalyzerTools.cpp
+++ b/preprocess/plugins/edanalyzerTools.cpp
@@ -220,7 +220,7 @@ void storeRestFrameVariables(std::map<std::string, float> &treeVars, std::vector
 
       // Now that PF candidates are stored, make the boost axis the Z-axis
       // Important for BES variables
-      pboost( thisJetLV.Vect(), thisParticleLV.Vect(), thisParticleLV);
+      //pboost( thisJetLV.Vect(), thisParticleLV.Vect(), thisParticleLV);
       particles.push_back( thisParticleLV );
       particles2.push_back( math::XYZVector( thisParticleLV.X(), thisParticleLV.Y(), thisParticleLV.Z() ));
       particles3.push_back( reco::LeafCandidate(+1, reco::Candidate::LorentzVector( thisParticleLV.X(), thisParticleLV.Y(),
@@ -253,7 +253,7 @@ void storeRestFrameVariables(std::map<std::string, float> &treeVars, std::vector
    double asymmetry             = sumPz/sumP;
    treeVars["asymmetry_"+frame] = asymmetry;
 
-   // Recluster the jets in the Higgs rest frame
+   // Recluster the jets in the heavy object rest frame
    JetDefinition jet_def(antikt_algorithm, 0.4);
    ClusterSequence cs(FJparticles, jet_def);
    vector<PseudoJet> jetsFJ = sorted_by_pt(cs.inclusive_jets(20.0));
@@ -278,26 +278,31 @@ void storeRestFrameVariables(std::map<std::string, float> &treeVars, std::vector
 
 void pboost( TVector3 pbeam, TVector3 plab, TLorentzVector &pboo ){
 
-   double pl = plab.Dot(pbeam);
-   pl *= double(1. / pbeam.Mag());
+    double pl = plab.Dot(pbeam);
+    pl *= double(1. / pbeam.Mag());
 
-   // set x axis direction along pbeam x (0,0,1)
-   TVector3 pbx;
+    // set x axis direction along pbeam x (0,0,1)
+    TVector3 pbx;
 
-   pbx.SetX(pbeam.Y());
-   pbx.SetY(-pbeam.X());
-   pbx.SetZ(0.0);
+    pbx.SetX(pbeam.Y());
+    pbx.SetY(-pbeam.X());
+    pbx.SetZ(0.0);
 
-   pbx *= double(1. / pbx.Mag());
+    pbx *= double(1. / pbx.Mag());
 
-   // set y axis direction along -pbx x pbeam
-   TVector3 pby;
+    // set y axis direction along -pbx x pbeam
+    TVector3 pby;
 
-   pby = -pbx.Cross(pbeam);
-   pby *= double(1. / pby.Mag());
+    pby = -pbx.Cross(pbeam);
+    pby *= double(1. / pby.Mag());
 
-   pboo.SetX((plab.Dot(pbx)));
-   pboo.SetY((plab.Dot(pby)));
-   pboo.SetZ(pl);
+    pboo.SetX((plab.Dot(pbx)));
+    pboo.SetY((plab.Dot(pby)));
+    pboo.SetZ(pl);
+
+    // Check for errors
+    if(pboo.M() <= 0.0){
+        std::cout << "ERROR: PF Candidates have negative or zero mass!!!!!" << std::endl;
+    }
 
 }

--- a/preprocess/test/run_TEST.py
+++ b/preprocess/test/run_TEST.py
@@ -68,7 +68,8 @@ process.countAK8Jets = cms.EDFilter("PATCandViewCountFilter",
 # Run the producer
 process.run = cms.EDProducer('HHESTIAProducer',
 	inputJetColl = cms.string('selectedAK8Jets'),
-        isSignal = cms.bool(True)
+        jetType = cms.string('H')
+        #isSignal = cms.string('H')
 )
 
 process.TFileService = cms.Service("TFileService", fileName = cms.string("preprocess_BEST_TEST.root") )


### PR DESCRIPTION
## Description

I have made extensive changes to the edanalyzer portion of the code:
- There is a generic rest frame function now
- This rest frame function can be used with any name and mass
- I have also created an enumerator in a specialized namespace so that jet Types can be easily passed to the rest frame function

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This is the first in a series of steps to update HHESTIA to BEST and ultimately make BEST a more modular, more robust software.

## How Has This Been Tested?
This has been tested with Higgs MC sample. A more extensive testing suite is needed. Ultimately, I want to create a testing suite capable of searching any changes made to the code for a series of common errors.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
