### PR TITLE
[Feature] Added Vectors for Secondary Vertices

### DIFF
--- a/preprocess/plugins/BESTProducer.cc
+++ b/preprocess/plugins/BESTProducer.cc
@@ -233,29 +233,13 @@ BESTProducer::BESTProducer(const edm::ParameterSet& iConfig):
 
     // Vertex Variables
     listOfVars.push_back("nSecondaryVertices");
-    listOfVars.push_back("SV_1_pt");
-    listOfVars.push_back("SV_1_eta");
-    listOfVars.push_back("SV_1_phi");
-    listOfVars.push_back("SV_1_mass");
-    listOfVars.push_back("SV_1_nTracks");
-    listOfVars.push_back("SV_1_chi2");
-    listOfVars.push_back("SV_1_Ndof");
-
-    listOfVars.push_back("SV_2_pt");
-    listOfVars.push_back("SV_2_eta");
-    listOfVars.push_back("SV_2_phi");
-    listOfVars.push_back("SV_2_mass");
-    listOfVars.push_back("SV_2_nTracks");
-    listOfVars.push_back("SV_2_chi2");
-    listOfVars.push_back("SV_2_Ndof");
-
-    listOfVars.push_back("SV_3_pt");
-    listOfVars.push_back("SV_3_eta");
-    listOfVars.push_back("SV_3_phi");
-    listOfVars.push_back("SV_3_mass");
-    listOfVars.push_back("SV_3_nTracks");
-    listOfVars.push_back("SV_3_chi2");
-    listOfVars.push_back("SV_3_Ndof");
+    listOfVecVars.push_back("SV_pt");
+    listOfVecVars.push_back("SV_eta");
+    listOfVecVars.push_back("SV_phi");
+    listOfVecVars.push_back("SV_mass");
+    listOfVecVars.push_back("SV_nTracks");
+    listOfVecVars.push_back("SV_chi2");
+    listOfVecVars.push_back("SV_Ndof");
 
     // Deep Jet b Discriminants
     //listOfVars.push_back("bDisc");
@@ -544,7 +528,7 @@ BESTProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
             // Secondary Vertex Variables
             TLorentzVector jet(ijet->px(), ijet->py(), ijet->pz(), ijet->energy() );
-            storeSecVertexVariables(treeVars, jet, secVertices);
+            storeSecVertexVariables(treeVars, jetVecVars, jet, secVertices);
 
             // Get all of the Jet's daughters
             vector<reco::Candidate * > daughtersOfJet;
@@ -582,7 +566,7 @@ BESTProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                     storeJetVariables(treeVars, ijet, jetColl_);
 
                     // Secondary Vertex Variables
-                    storeSecVertexVariables(treeVars, jet, secVertices);
+                    storeSecVertexVariables(treeVars, jetVecVars, jet, secVertices);
 
                     // Get all of the Jet's daughters
                     vector<reco::Candidate * > daughtersOfJet;
@@ -622,7 +606,7 @@ BESTProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                     storeJetVariables(treeVars, ijet, jetColl_);
 
                     // Secondary Vertex Variables
-                    storeSecVertexVariables(treeVars, jet, secVertices);
+                    storeSecVertexVariables(treeVars, jetVecVars, jet, secVertices);
 
                     // Get all of the Jet's daughters
                     vector<reco::Candidate * > daughtersOfJet;
@@ -662,7 +646,7 @@ BESTProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                     storeJetVariables(treeVars, ijet, jetColl_);
 
                     // Secondary Vertex Variables
-                    storeSecVertexVariables(treeVars, jet, secVertices);
+                    storeSecVertexVariables(treeVars, jetVecVars, jet, secVertices);
 
                     // Get all of the Jet's daughters
                     vector<reco::Candidate * > daughtersOfJet;
@@ -702,7 +686,7 @@ BESTProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                     storeJetVariables(treeVars, ijet, jetColl_);
 
                     // Secondary Vertex Variables
-                    storeSecVertexVariables(treeVars, jet, secVertices);
+                    storeSecVertexVariables(treeVars, jetVecVars, jet, secVertices);
 
                     // Get all of the Jet's daughters
                     vector<reco::Candidate * > daughtersOfJet;

--- a/preprocess/plugins/BESTtoolbox.cpp
+++ b/preprocess/plugins/BESTtoolbox.cpp
@@ -173,7 +173,8 @@ void storeJetVariables(std::map<std::string, float> &treeVars, std::vector<pat::
 // used to fill the tree -----------------------------------------------------------------
 //----------------------------------------------------------------------------------------
 
-void storeSecVertexVariables(std::map<std::string, float> &treeVars, TLorentzVector jet,
+void storeSecVertexVariables(std::map<std::string, float> &treeVars,
+                             std::map<std::string, std::vector<float> > &jetVecVars, TLorentzVector jet,
                              std::vector<reco::VertexCompositePtrCandidate> secVertices){
 
    int numMatched = 0; // counts number of secondary vertices
@@ -184,16 +185,13 @@ void storeSecVertexVariables(std::map<std::string, float> &treeVars, TLorentzVec
       if(jet.DeltaR(vert) < 0.8 ){
          numMatched++;
          // save secondary vertex info for the first three sec vertices
-         if(numMatched <= 3){
-            std::string i = std::to_string(numMatched);
-            treeVars["SV_"+i+"_pt"] = ivert->pt();
-            treeVars["SV_"+i+"_eta"] = ivert->eta();
-            treeVars["SV_"+i+"_phi"] = ivert->phi();
-            treeVars["SV_"+i+"_mass"] = ivert->mass();
-            treeVars["SV_"+i+"_nTracks"] = ivert->numberOfDaughters();
-            treeVars["SV_"+i+"_chi2"] = ivert->vertexChi2();
-            treeVars["SV_"+i+"_Ndof"] = ivert->vertexNdof();
-         }
+         jetVecVars["SV_pt"].push_back(ivert->pt() );
+         jetVecVars["SV_eta"].push_back(ivert->eta() );
+         jetVecVars["SV_phi"].push_back(ivert->phi() );
+         jetVecVars["SV_mass"].push_back(ivert->mass() );
+         jetVecVars["SV_nTracks"].push_back(ivert->numberOfDaughters() );
+         jetVecVars["SV_chi2"].push_back(ivert->vertexChi2() );
+         jetVecVars["SV_Ndof"].push_back(ivert->vertexNdof() );
       }
    }
    treeVars["nSecondaryVertices"] = numMatched;

--- a/preprocess/plugins/BESTtoolbox.h
+++ b/preprocess/plugins/BESTtoolbox.h
@@ -43,8 +43,8 @@ void getJetDaughters(std::vector<reco::Candidate * > &daughtersOfJet, std::vecto
 void storeJetVariables(std::map<std::string, float> &treeVars, std::vector<pat::Jet>::const_iterator jet, int jetColl);
 
 // store the secondary vertex variables
-void storeSecVertexVariables(std::map<std::string, float> &treeVars, TLorentzVector jet,
-                             std::vector<reco::VertexCompositePtrCandidate> secVertices);
+void storeSecVertexVariables(std::map<std::string, float> &treeVars, std::map< std::string, std::vector<float> > &jetVecVars,
+                             TLorentzVector jet, std::vector<reco::VertexCompositePtrCandidate> secVertices);
 
 // store the rest frame variables
 void storeRestFrameVariables(std::map<std::string, float> &treeVars, std::vector<reco::Candidate *> daughtersOfJet,


### PR DESCRIPTION
Now the code can store information about multiple secondary vertices by using vectors

## Description
This change involved converting some floats to vectors

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This will allow for more storage of SVs to be used in future versions of BEST

## How Has This Been Tested?
First CMSSW was compiled. Then: 
```bash
cmsRun preprocess/test/run_TEST.py
python BES_variable_testingSuite.py
```
The output `preprocess_BEST_TEST.root` file was investigated to have stored the correct information


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
